### PR TITLE
Update lock_events.c

### DIFF
--- a/kernel/locking/lock_events.c
+++ b/kernel/locking/lock_events.c
@@ -146,7 +146,7 @@ static int __init init_lockevent_counts(void)
 	struct dentry *d_counts = debugfs_create_dir(LOCK_EVENTS_DIR, NULL);
 	int i;
 
-	if (IS_ERR(d_counts))
+	if (!d_counts)
 		goto out;
 
 	/*
@@ -159,14 +159,14 @@ static int __init init_lockevent_counts(void)
 	for (i = 0; i < lockevent_num; i++) {
 		if (skip_lockevent(lockevent_names[i]))
 			continue;
-		if (IS_ERR(debugfs_create_file(lockevent_names[i], 0400, d_counts,
-					 (void *)(long)i, &fops_lockevent)))
+		if (!debugfs_create_file(lockevent_names[i], 0400, d_counts,
+					 (void *)(long)i, &fops_lockevent))
 			goto fail_undo;
 	}
 
-	if (IS_ERR(debugfs_create_file(lockevent_names[LOCKEVENT_reset_cnts], 0200,
+	if (!debugfs_create_file(lockevent_names[LOCKEVENT_reset_cnts], 0200,
 				 d_counts, (void *)(long)LOCKEVENT_reset_cnts,
-				 &fops_lockevent)))
+				 &fops_lockevent))
 		goto fail_undo;
 
 	return 0;
@@ -177,3 +177,4 @@ out:
 	return -ENOMEM;
 }
 fs_initcall(init_lockevent_counts);
+


### PR DESCRIPTION
fix: replace IS_ERR checks with null pointer checks in init_lockevent_counts()

debugfs_create_dir() and debugfs_create_file() return NULL on failure, not ERR_PTR. Using IS_ERR() caused incorrect error handling and potential resource leaks. This commit updates the checks to properly verify null pointers, ensuring robust debugfs entry creation and cleanup